### PR TITLE
Fixed #3 & #4 & #5 and "next" command is fully working properly.

### DIFF
--- a/src/breakpoint.h
+++ b/src/breakpoint.h
@@ -27,7 +27,7 @@ public:
     bool enable();
     // Deleting the breakpoint at a specific address [m_addr] of process [m_pid] and restore the old instruction.
     void disable();
-    // Restore the instruction which the breakpoint was set without deleting the breakpoint.
+    // Restore the instruction which the breakpoint was set without deleting the breakpoint location.
     void stop_execution();
 
     // is (this) object of the class has an active breakpoint.
@@ -44,7 +44,7 @@ private:
     bool m_enabled;
     // the lower byte of the instruction at address [m_addr] which is replaced
     // with INT3 byte for making a breakpoint in x86 processors.
-    long m_saved_data;
+    uint8_t m_saved_data;
 };
 
 #endif

--- a/src/debugger.cpp
+++ b/src/debugger.cpp
@@ -344,9 +344,10 @@ void debugger::next_instruction()
     {
         if (bp->second.is_enabled())
         {
-            std::cout << "Next: found a breakpoint\n";
-            this->continue_execution();
-            return;
+            bp->second.disable();
+            ptrace(PTRACE_SINGLESTEP, m_pid, nullptr, nullptr);
+            signal_status = wait_for_signal();
+            bp->second.enable();
         }
     }
     else{


### PR DESCRIPTION
The problem with old way of "next" command when a breakpoint exist is it continues the execution to the end of program not to the next instruction :'D .  I haven't seen that coming since #5 issue was missing with instruction data in the background so i ended with the bad idea of continue_execution() inside the "next" command. 
Anyway it is solved now. 